### PR TITLE
update jsSHA version to allow plugin installation

### DIFF
--- a/insomnia/insomnia-plugin-platform-of-trust/package.json
+++ b/insomnia/insomnia-plugin-platform-of-trust/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@platform-of-trust/insomnia-plugin-platform-of-trust",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "description": "Platform of Trust plugin for Insomnia REST Client",
     "main": "index.js",
     "scripts": {
@@ -13,7 +13,7 @@
     "license": "MIT",
     "dependencies": {
         "json-stable-stringify": "^1.0.1",
-        "jssha": "^2.3.1"
+        "jssha": "^3.1.2"
     },
     "devDependencies": {}
 }


### PR DESCRIPTION
jsSHA 2.3.1 displays warning while installation, so insomnia rejects plugin installation
I`v updated jsSHA version in package.json up to 3.1.2 and make sure that it works right